### PR TITLE
Make URLs of git repositories HTTP proxy friendly

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,13 +9,13 @@
            ]}.
 
 {deps,  [
-         {lager, ".*", {git, "git://github.com/basho/lager.git", "master"}},
-         {of_protocol, ".*", {git, "https://github.com/FlowForwarding/LINC-OF-Protocol.git", "master"}},
-         {meck, "0\.7\..*", {git, "git://github.com/eproxus/meck.git", "master"}},
-         {pkt, ".*", {git, "git://github.com/esl/pkt.git", "master"}},
-         {procket, ".*", {git, "git://github.com/msantos/procket.git", "master"}},
-         {epcap, ".*", {git, "git://github.com/esl/epcap.git", "master"}},
-         {tunctl, ".*", {git, "git://github.com/msantos/tunctl.git", "master"}}
+         {lager, ".*", {git, "http://github.com/basho/lager.git", "master"}},
+         {of_protocol, ".*", {git, "http://github.com/FlowForwarding/LINC-OF-Protocol.git", "master"}},
+         {meck, "0\.7\..*", {git, "http://github.com/eproxus/meck.git", "master"}},
+         {pkt, ".*", {git, "http://github.com/esl/pkt.git", "master"}},
+         {procket, ".*", {git, "http://github.com/msantos/procket.git", "master"}},
+         {epcap, ".*", {git, "http://github.com/esl/epcap.git", "master"}},
+         {tunctl, ".*", {git, "http://github.com/msantos/tunctl.git", "master"}}
         ]}.
 
 {cover_enabled, true}.


### PR DESCRIPTION
Dear LINC developers, 

I tried to build LINC-Switch behind a HTTP proxy, but it failed because the git repositories in rebar.config are written as git native protocol URLs. Then, I changed them to HTTP based URLs. 

I think HTTP based URLs are more convenient than git based URLs when we are behind a HTTP proxy (for example in companies with security considerations). 

I hope this patch helps you.

Best regards,
Sho
