### PR TITLE
Assign a MAC address to the switch

### DIFF
--- a/apps/of_switch/src/ofs_userspace_port.erl
+++ b/apps/of_switch/src/ofs_userspace_port.erl
@@ -284,18 +284,11 @@ init({OfsPortNo, ConfigOpts}) ->
                                     [public,
                                      {read_concurrency, true},
                                      {keypos, #ofs_queue_throttling.queue_no}]),
-            HwAddr = case inet:ifget(Interface, [hwaddr]) of
-                         [] ->
-                             undefined;
-                         {ok, [{hwaddr, [M1, M2, M3, M4, M5, M6]}]} ->
-                             <<M1, M2, M3, M4, M5, M6>>
-                     end,
             OfsPort = #ofs_port{number = OfsPortNo,
                                 type = physical,
                                 pid = self(),
                                 iface = Interface,
-                                port = #ofp_port{port_no = OfsPortNo,
-                                                 hw_addr = HwAddr}},
+                                port = #ofp_port{port_no = OfsPortNo}},
             ets:insert(ofs_ports, OfsPort),
             ets:insert(port_stats, #ofp_port_stats{port_no = OfsPortNo}),
             State1 = State#state{interface = Interface,


### PR DESCRIPTION
This pull request fixes issue #14

It works with NOX controller, but when Floodlight is connected, there are warnings on the switch side: `[warning] unsupported port type: flood`
