### PR TITLE
Make sure MAC used for datapathid is /=0:0:0:0:0:0

### DIFF
--- a/apps/linc/src/linc_logic.erl
+++ b/apps/linc/src/linc_logic.erl
@@ -359,7 +359,9 @@ send_reply(Socket, Request, ReplyBody) ->
 
 get_datapath_mac() ->
     {ok,Ifs}=inet:getifaddrs(),
-    [MAC|_] = [hw_addr(Ps)||{_IF,Ps}<-Ifs, lists:keymember(hwaddr,1,Ps)],
+    MACs =  [hw_addr(Ps)||{_IF,Ps}<-Ifs, lists:keymember(hwaddr,1,Ps)],
+    %% Make sure MAC/=0
+    [MAC|_] = [M||M <- MACs, M/=[0,0,0,0,0,0]],
     list_to_binary(MAC).
     
 hw_addr(Ps) ->


### PR DESCRIPTION
Datapath id is chosen from the MAC addresses of existing interfaces.
Make sure that it is not 0:0:0:0:0:0.
