### PR TITLE
Add comment to config file explaining auxiliary connections usage

### DIFF
--- a/rel/files/sys.config
+++ b/rel/files/sys.config
@@ -56,6 +56,13 @@
        {controllers,
         [
          %% {"Switch0-DefaultController", "localhost", 6633, tcp}
+
+         %% To establish auxiliary connections to the controller specify them
+         %% in the list of additional options. For example to start 2 tcp and one
+         %% tls auxiliary connections provide config as follows:
+         %% {"Switch0-DefaultController", "localhost", 6633, tcp,
+         %%  [{auxiliary_connections, [{tcp, 2}, {tls, 1}]}]
+         %% }
         ]},
 
        %% Enable or disable queues subsystem. Queue configuration is not part


### PR DESCRIPTION
Motivated by #125. Should be merged along with https://github.com/FlowForwarding/of_protocol/pull/31
