### PR TITLE
Add a comment explaining assignment of capable switch ports to a logical switch.

### DIFF
--- a/rel/files/sys.config
+++ b/rel/files/sys.config
@@ -71,6 +71,10 @@
        %% Allowed values: 'enabled' | 'disabled'
        {queues_status, disabled},
 
+       %% To assign a port to a logical switch two requirements has to be meet:
+       %%    a. the port has to be defined in the `capable_switch_ports`,
+       %%    b. the port has to be listed in the `ports` for the logical switch.
+       %%
        %% If queues are enabled, assign them to ports.
        %% Remember to set appropriate port rates in `capable_switch_ports`.
        %% Queue configuration is not part of the OpenFlow specification


### PR DESCRIPTION
Fixes #99
