### PR TITLE
Use type tuple() instead of record()

### DIFF
--- a/apps/linc_us3/include/linc_us3_port.hrl
+++ b/apps/linc_us3/include/linc_us3_port.hrl
@@ -9,9 +9,9 @@
 %% LINC swich port configuration stored in sys.config
 -type linc_port_config() :: tuple(interface, string())
                           | tuple(ip, string())
-                          | tuple(config, record())
-                          | tuple(features, record())
-                          | tuple(queues, record()).
+                          | tuple(config, tuple())
+                          | tuple(features, tuple())
+                          | tuple(queues, tuple()).
 
 -type linc_port_type() :: physical | logical | reserved.
 -type linc_queues_state() :: enabled | disabled.

--- a/apps/linc_us4/include/linc_us4_port.hrl
+++ b/apps/linc_us4/include/linc_us4_port.hrl
@@ -9,9 +9,9 @@
 %% LINC swich port configuration stored in sys.config
 -type linc_port_config() :: tuple(interface, string())
                           | tuple(ip, string())
-                          | tuple(config, record())
-                          | tuple(features, record())
-                          | tuple(queues, record()).
+                          | tuple(config, tuple())
+                          | tuple(features, tuple())
+                          | tuple(queues, tuple()).
 
 -type linc_port_type() :: physical | logical | reserved.
 -type linc_queues_state() :: enabled | disabled.


### PR DESCRIPTION
Dialyzer doesn't recognize the type record(), so let's use tuple()
instead.
