### PR TITLE
Allow for sys.config file without controllers_listener parameter

### DIFF
--- a/apps/linc/src/linc.erl
+++ b/apps/linc/src/linc.erl
@@ -83,9 +83,12 @@ controllers_for_switch(SwitchId, Config) ->
 -spec controllers_listener_for_switch(integer(), term()) -> tuple() | disabled.
 controllers_listener_for_switch(SwitchId, Config) ->
     {switch, SwitchId, Opts} = lists:keyfind(SwitchId, 2, Config),
-    {controllers_listener, ControllersListener}  =
-        lists:keyfind(controllers_listener, 1, Opts),
-    ControllersListener.
+    case lists:keyfind(controllers_listener, 1, Opts) of
+        {controllers_listener, ControllersListener}  ->
+            ControllersListener;
+        false ->
+            disabled
+    end.
 
 %%------------------------------------------------------------------------------
 %% Local helpers


### PR DESCRIPTION
For backward compatibility the controllers_listener parameter,
that decide whether active controllers can connect to the switch, should
not be required.
(Motivated by #147).
