### PR TITLE
Change meck dependency to tag 0.8.1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -20,7 +20,7 @@
    {git, "https://github.com/FlowForwarding/of_config.git", {branch, "master"}}},
   {pkt, ".*", {git, "http://github.com/esl/pkt.git", {branch, "master"}}},
   {meck, ".*", {git, "http://github.com/eproxus/meck.git",
-                "8433cf2e07862ea8c66e85e2578b7146b4332354"}},
+                {tag, "0.8.1"}}},
   {procket, ".*", {git, "http://github.com/msantos/procket.git",
                    "0c32f661dc54aeff9c89a4ced3449eb9856a531f"}},
   {epcap, ".*", {git, "http://github.com/esl/epcap.git",


### PR DESCRIPTION
Crucially, this removes a test for parameterised modules, which are no
longer supported in R16.
