### PR TITLE
Log changes to flow entries on debug loglevel

### DIFF
--- a/apps/linc_us4/src/linc_us4_flow.erl
+++ b/apps/linc_us4/src/linc_us4_flow.erl
@@ -473,6 +473,8 @@ add_new_flow(SwitchId, TableId,
                       IdleTime, HardTime),
     ets:insert(flow_table_ets(SwitchId, TableId), NewEntry),
     increment_group_ref_count(SwitchId, Instructions),
+    ?DEBUG("[FLOWMOD] Added new flow entry with id ~w: ~w",
+           [NewEntry#flow_entry.id, FlowMod]),
     ok.
 
 %% Delete a flow
@@ -490,6 +492,8 @@ delete_flow(SwitchId, TableId,
     ets:delete(linc:lookup(SwitchId, flow_entry_counters), FlowId),
     delete_flow_timer(SwitchId, FlowId),
     decrement_group_ref_count(SwitchId, Instructions),
+    ?DEBUG("[FLOWMOD] Deleted flow entry with id ~w: ~w",
+           [FlowId, Flow]),
     ok.
 
 send_flow_removed(SwitchId, TableId,
@@ -917,6 +921,8 @@ replace_existing_flow(SwitchId, TableId,
             NewEntry = create_flow_entry(FlowMod),
             ets:insert(flow_table_ets(SwitchId, TableId),
                        NewEntry#flow_entry{id=Id}),
+            ?DEBUG("[FLOWMOD] Replaced flow entry ~w with: ~w",
+                   [Id, NewEntry]),
             ok
     end.
 
@@ -927,6 +933,8 @@ modify_flow(SwitchId, TableId, #flow_entry{id=Id,instructions=PrevInstructions},
     ets:update_element(flow_table_ets(SwitchId, TableId),
                        Id,
                        {#flow_entry.instructions, NewInstructions}),
+    ?DEBUG("[FLOWMOD] New instructions for flow entry ~w: ~w",
+           [Id, NewInstructions]),
     increment_group_ref_count(SwitchId, NewInstructions),
     decrement_group_ref_count(SwitchId, PrevInstructions),
     case lists:member(reset_counts, Flags) of


### PR DESCRIPTION
The log entries look like this:

```
2013-10-30 15:02:52.519 [debug] <0.646.0>@linc_us4_flow:add_new_flow:476 [FLOWMOD] Added new flow entry with id {1,#Ref<0.0.0.503>}: {ofp_flow_mod,<<0,0,0,0,0,0,0,0>>,<<0,0,0,0,0,0,0,0>>,0,add,0,0,1,no_buffer,any,any,[],{ofp_match,[{ofp_field,openflow_basic,eth_type,false,<<8,0>>,undefined},{ofp_field,openflow_basic,ipv4_src,false,<<192,168,0,68>>,undefined}]},[{ofp_instruction_apply_actions,2,[{ofp_action_set_field,13,{ofp_field,openflow_basic,ipv4_dst,false,<<10,0,0,68>>,undefined}},{ofp_action_output,16,2,no_buffer}]}]}
2013-10-30 15:05:36.406 [debug] <0.646.0>@linc_us4_flow:replace_existing_flow:924 [FLOWMOD] Replaced flow entry {1,#Ref<0.0.0.503>} with: {flow_entry,{1,#Ref<0.0.0.704>},1,{ofp_match,[{ofp_field,openflow_basic,eth_type,false,<<8,0>>,undefined},{ofp_field,openflow_basic,ipv4_src,false,<<192,168,0,68>>,undefined}]},<<0,0,0,0,0,0,0,0>>,[],{1383,145536,406355},{infinity,0,0},{infinity,0,0},[{ofp_instruction_apply_actions,2,[{ofp_action_set_field,13,{ofp_field,openflow_basic,ipv4_dst,false,<<10,0,0,68>>,undefined}},{ofp_action_output,16,2,no_buffer}]}]}
2013-10-30 15:05:37.025 [debug] <0.646.0>@linc_us4_flow:delete_flow:495 [FLOWMOD] Deleted flow entry with id {1,#Ref<0.0.0.503>}: {flow_entry,{1,#Ref<0.0.0.503>},1,{ofp_match,[{ofp_field,openflow_basic,eth_type,false,<<8,0>>,undefined},{ofp_field,openflow_basic,ipv4_src,false,<<192,168,0,68>>,undefined}]},<<0,0,0,0,0,0,0,0>>,[],{1383,145536,406355},{infinity,0,0},{infinity,0,0},[{ofp_instruction_apply_actions,2,[{ofp_action_set_field,13,{ofp_field,openflow_basic,ipv4_dst,false,<<10,0,0,68>>,undefined}},{ofp_action_output,16,2,no_buffer}]}]}
```
