### PR TITLE
Fix Ethertype check for push MPLS action

### DIFF
--- a/apps/linc_us4/src/linc_us4_flow.erl
+++ b/apps/linc_us4/src/linc_us4_flow.erl
@@ -859,7 +859,7 @@ validate_action(_SwitchId, #ofp_action_push_vlan{}, _Match) ->
 validate_action(_SwitchId, #ofp_action_pop_vlan{}, _Match) ->
     ok;
 validate_action(_SwitchId, #ofp_action_push_mpls{ethertype=Ether}, _Match)
-  when Ether == 16#8100; Ether==16#88A8 ->
+  when Ether==16#8847; Ether==16#8848 ->
     ok;
 validate_action(_SwitchId, #ofp_action_push_mpls{}, _Match) ->
     {error,{bad_action,bad_argument}};


### PR DESCRIPTION
Expect ethertype 8847 (MPLS), not 88A8 (VLAN).

This closes FlowForwarding/LINC-Switch#209.
