### PR TITLE
of_controller_v4: set max_len field on ofp_action_output when needed

### DIFF
--- a/scripts/of_controller_v4.erl
+++ b/scripts/of_controller_v4.erl
@@ -997,7 +997,7 @@ flow_mod_output_to_port(InPort, OutPort, MaxLen) ->
                             name = in_port,
                             value = <<InPort:32>>},
     Match = #ofp_match{fields = [MatchField]},
-    Action = case InPort =:= controller of
+    Action = case OutPort =:= controller of
                  true ->
                      #ofp_action_output{port = OutPort, max_len = MaxLen};
                  false ->


### PR DESCRIPTION
This change makes the code agree with the comment just above it: when
asking the switch to output packets to the controller, use the specified
max_len value.
