### PR TITLE
Fix error message for port_mod to non-existent port

### DIFF
--- a/apps/linc_us4/test/linc_us4_port_tests.erl
+++ b/apps/linc_us4/test/linc_us4_port_tests.erl
@@ -65,7 +65,7 @@ port_test_() ->
 port_mod() ->
     BadPort = 999,
     PortMod1 = #ofp_port_mod{port_no = BadPort},
-    Error1 = {error, {bad_request, bad_port}},
+    Error1 = {error, {port_mod_failed, bad_port}},
     ?assertEqual(Error1, linc_us4_port:modify(?SWITCH_ID, PortMod1)),
 
     Port = 1,


### PR DESCRIPTION
Return OFPET_PORT_MOD_FAILED + OFPPMFC_BAD_PORT instead of
OFPET_BAD_REQUEST + OFPBRC_BAD_PORT.

This closes FlowForwarding/LINC-Switch#238.
