### PR TITLE
of-config: fix a crash on get-config startup

### DIFF
--- a/apps/linc/src/linc_ofconfig.erl
+++ b/apps/linc/src/linc_ofconfig.erl
@@ -636,13 +636,15 @@ convert_before_merge(#ofconfig{ports = Ports,
       || {switch, SwitchId, DatapathId} <- Switches]}.
 
 filter_switch_resources(SwitchId, Resources) ->
-    lists:map(fun({port, {PortId, SId}, _, _}) when SId == SwitchId ->
-                      {port, resource_id(port, {SId, PortId})};
-                 ({queue, {QueueId, PortId, SId}, _, _}) when SId == SwitchId ->
-                      {queue, resource_id(queue, {SId, PortId, QueueId})};
-                 (_) ->
-                      false
-              end, Resources).
+    %% filtermap
+    lists:reverse(lists:foldl(
+        fun({port, {PortId, SId}, _, _}, Acc) when SId == SwitchId ->
+               [{port, resource_id(port, {SId, PortId})}|Acc];
+           ({queue, {QueueId, PortId, SId}, _, _}, Acc) when SId == SwitchId ->
+               [{queue, resource_id(queue, {SId, PortId, QueueId})}|Acc];
+           (_, Acc) ->
+               Acc
+        end, [], Resources)).
 
 convert_ports_before_merge(Ports) ->
     [#port{resource_id = resource_id(port, {PSwitchId, PortId}),


### PR DESCRIPTION
2013-11-28 16:19:26 =CRASH REPORT====
  crasher:
    initial call: linc_ofconfig:init/1
    pid: <0.638.0>
    registered_name: linc_ofconfig
    exception exit: {{function_clause,[{of_config_encoder,'-simple_form/1-fun-1-',[false],[{file,"src/of_config_encoder.erl"},{line,250}]},{lists,map,2,[{file,"lists.erl"},{line,1224}]},{lists,map,2,[{file,"lists.erl"},{line,1224}]},{of_config_encoder,simple_form,1,[{file,"src/of_config_encoder.erl"},{line,250}]},{lists,map,2,[{file,"lists.erl"},{line,1224}]},{of_config_encoder,element,3,[{file,"src/of_config_encoder.erl"},{line,317}]},{of_config_encoder,simple_form,1,[{file,"src/of_config_encoder.erl"},{line,70}]},{linc_ofconfig,handle_call,3,[{file,"src/linc_ofconfig.erl"},{line,414}]}]},[{gen_server,terminate,6,[{file,"gen_server.erl"},{line,747}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,239}]}]}
