### PR TITLE
Fix some changes with ssh starting

### DIFF
--- a/apps/linc/src/linc_capable_sup.erl
+++ b/apps/linc/src/linc_capable_sup.erl
@@ -84,6 +84,8 @@ backend_for_switch(SwitchId) ->
 start_ofconfig(Pid) ->
     case application:get_env(linc, of_config) of
         {ok, enabled} ->
+	    start_dependency(asn1),
+	    start_dependency(public_key),
             start_dependency(ssh),
             start_dependency(enetconf),
             OFConfig = {linc_ofconfig, {linc_ofconfig, start_link, []},

--- a/apps/linc/test/linc_tests.erl
+++ b/apps/linc/test/linc_tests.erl
@@ -67,6 +67,7 @@ logic() ->
 
 setup() ->
     error_logger:tty(false),
+    ok = application:start(asn1),
     ok = application:start(public_key),
     ok = application:start(ssh),
     ok = application:start(xmerl),
@@ -83,6 +84,7 @@ teardown(_) ->
     ok = application:stop(xmerl),
     ok = application:stop(lager),
     ok = application:stop(public_key),
+    ok = application:stop(asn1),
     ok = application:stop(ssh).
 
 %% Helper functions ------------------------------------------------------------


### PR DESCRIPTION
Hello, I tested some Makefile targets and met some errors. 

```
#make test
** in function linc_tests:setup/0 (test/linc_tests.erl, line 70)
** error: {badmatch, {error, {not_started, asn1}}
```

The changes in `linc_tests.erl` decide this problem.

```
#make dev
{error, {not_started, public_key}}
{error, {not_started, ssh}}
```

The changes in `linc_capable_sup.erl` decide this problem.

R16B01; Ubuntu 13.10 with kernel 3.11.0-12-generic

Best Regards,
Ihar Kukharchuk
EPAM Systems
