### PR TITLE
Fix rebar.config so that master branch for epcap is used

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -24,7 +24,7 @@
   {procket, ".*", {git, "https://github.com/msantos/procket.git",
                    "0c32f661dc54aeff9c89a4ced3449eb9856a531f"}},
   {epcap, ".*", {git, "https://github.com/esl/epcap.git",
-                 "367db4e194f4a0ec88abd3582a33fbf1eaa91e34"}},
+                 {branch, "master"}}},
   {tunctl, ".*", {git, "https://github.com/msantos/tunctl.git",
                   "4faf1a52f1b364df6eb71176477861dbf60dcf0f"}},
   {sync, ".*",


### PR DESCRIPTION
The dependency configuration pointed to a specific commit.
(Motivated by #283).
