### PR TITLE
Modify tests covering modification of UDP packets

### DIFF
--- a/apps/linc_us4/test/linc_us4_packet_tests.erl
+++ b/apps/linc_us4/test/linc_us4_packet_tests.erl
@@ -253,6 +253,8 @@ encode(Packet = #ndp_na{}) ->
 encode(Packet = #ndp_ns{}) ->
     Ipv6 = #ipv6{saddr = <<0:128>>, daddr = <<0:128>>},
     pkt:encapsulate([Ipv6, #icmpv6{}, Packet]);
+encode(Packet = #udp{}) ->
+    pkt_udp:encapsulate(Packet, #ipv4{}, <<>>);
 encode(_Packet = #sctp{}) ->
     %% pkt.erl cannot encode SCTP packets
     ignore;


### PR DESCRIPTION
After refactoring pkt application and extracting UDP related code to
a separate module, tests for UDP in linc_us4_packet stopped working.
(Motivated by #276).
