### PR TITLE
Add OFPVID_PRESENT bit to VLAN match field in packet-in message

### DIFF
--- a/apps/linc_us3/src/linc_us3_convert.erl
+++ b/apps/linc_us3/src/linc_us3_convert.erl
@@ -63,8 +63,9 @@ special_header_fields(P) ->
             [ofp_field(eth_type, <<(Ether#ether.type):16>>)];
         %% found VLAN header - take eth_type from it, also set other fields
         {_, VLAN} ->
+            <<VID:12>> = VLAN#ieee802_1q_tag.vid,
             [ofp_field(eth_type, <<(VLAN#ieee802_1q_tag.ether_type):16>>),
-             ofp_field(vlan_vid, VLAN#ieee802_1q_tag.vid),
+             ofp_field(vlan_vid, <<(?OFPVID_PRESENT bor VID):13>>),
              ofp_field(vlan_pcp, <<(VLAN#ieee802_1q_tag.pcp):3>>)]
     end.
 

--- a/apps/linc_us3/test/linc_us3_convert_tests.erl
+++ b/apps/linc_us3/test/linc_us3_convert_tests.erl
@@ -61,13 +61,14 @@ ether_ignore_vlan() ->
 %% Issue reported and described here:
 %% https://github.com/FlowForwarding/LINC-Switch/issues/3
 vlan_match_only_outer() ->
-    P1 = [#ether{}, #ieee802_1q_tag{vid=333}, #ieee802_1q_tag{vid=444}],
+    P1 = [#ether{}, #ieee802_1q_tag{vid = <<333:12>>},
+          #ieee802_1q_tag{vid = <<444:12>>}],
     Fields1 = linc_us3_convert:packet_fields(P1),
     F1 = lists:filter(fun(X) -> X#ofp_field.name == vlan_vid end, Fields1),
     ?assert(length(F1) =:= 1), % exactly 1 field added
     [VLAN1 | _] = F1,
     ?assert(VLAN1 =/= false),
-    ?assert(VLAN1#ofp_field.value =:= 333).
+    ?assert(VLAN1#ofp_field.value =:= <<(?OFPVID_PRESENT bor 333):13>>).
 
 %% Fixtures --------------------------------------------------------------------
 

--- a/apps/linc_us4/src/linc_us4_convert.erl
+++ b/apps/linc_us4/src/linc_us4_convert.erl
@@ -61,12 +61,13 @@ eth_and_vlan_fields(P) ->
                      ofp_field(eth_dst, DHost),
                      ofp_field(eth_src, SHost)];
                 {_, #ieee802_1q_tag{ether_type = VlanType,
-                                    vid = VID,
+                                    vid = <<VID:12>>,
                                     pcp = PCP}} ->
                     [ofp_field(eth_dst, DHost),
                      ofp_field(eth_src, SHost),
                      ofp_field(eth_type, <<VlanType:16>>),
-                     ofp_field(vlan_vid, VID),
+                     ofp_field(vlan_vid,
+                               <<(?OFPVID_PRESENT bor VID):13>>),
                      ofp_field(vlan_pcp, <<PCP:3>>)]
             end
     end.

--- a/apps/linc_us5/src/linc_us5_convert.erl
+++ b/apps/linc_us5/src/linc_us5_convert.erl
@@ -61,12 +61,13 @@ eth_and_vlan_fields(P) ->
                      ofp_field(eth_dst, DHost),
                      ofp_field(eth_src, SHost)];
                 {_, #ieee802_1q_tag{ether_type = VlanType,
-                                    vid = VID,
+                                    vid = <<VID:12>>,
                                     pcp = PCP}} ->
                     [ofp_field(eth_dst, DHost),
                      ofp_field(eth_src, SHost),
                      ofp_field(eth_type, <<VlanType:16>>),
-                     ofp_field(vlan_vid, VID),
+                     ofp_field(vlan_vid,
+                               <<(?OFPVID_PRESENT bor VID):13>>),
                      ofp_field(vlan_pcp, <<PCP:3>>)]
             end
     end.

--- a/apps/linc_us5/test/linc_us5_convert_tests.erl
+++ b/apps/linc_us5/test/linc_us5_convert_tests.erl
@@ -61,11 +61,12 @@ ether() ->
 
 vlan() ->
     Packet = [#ether{dhost = dhost, shost = shost, type = 1},
-              #ieee802_1q_tag{vid = 1, pcp = 2, ether_type = 2}],
+              #ieee802_1q_tag{vid = <<(VID = 16#0050):12>>,
+                              pcp = 2, ether_type = 2}],
     check_packet(Packet, [{eth_dst, dhost},
                           {eth_src, shost},
                           {eth_type, <<2:16>>},
-                          {vlan_vid, 1},
+                          {vlan_vid, <<(?OFPVID_PRESENT bor VID):13>>},
                           {vlan_pcp, <<2:3>>}]).
 
 arp() ->
@@ -175,13 +176,14 @@ ether_ignore_vlan() ->
 %% Issue reported and described here:
 %% https://github.com/FlowForwarding/LINC-Switch/issues/3
 vlan_match_only_outer() ->
-    P1 = [#ether{}, #ieee802_1q_tag{vid=333}, #ieee802_1q_tag{vid=444}],
+    P1 = [#ether{}, #ieee802_1q_tag{vid = <<333:12>>},
+          #ieee802_1q_tag{vid = <<444:12>>}],
     Fields1 = linc_us5_convert:packet_fields(P1),
     F1 = lists:filter(fun(X) -> X#ofp_field.name == vlan_vid end, Fields1),
     ?assert(length(F1) =:= 1), % exactly 1 field added
     [VLAN1 | _] = F1,
     ?assert(VLAN1 =/= false),
-    ?assert(VLAN1#ofp_field.value =:= 333).
+    ?assert(VLAN1#ofp_field.value =:= <<(?OFPVID_PRESENT bor 333):13>>).
 
 %% Fixtures --------------------------------------------------------------------
 


### PR DESCRIPTION
This commit introduces setting the 13rd bit in the oxm_value of match
field for VLAN in packet-in message. For example if the VLAN ID in
a packet has a value of 0x0050 the resulting oxm_value in the match
field will have (0x1000 AND 0x0050). The change affects linc_us{3,4,5}.

Setting the match field for VLAN is optional in packet-in message
and is NOT explicitly defined in the OFP 1.{2,3,4} specifications.

Motivated by #328.
