### PR TITLE
Describe of_protocol's no_multipart flag in sys.config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,4 +47,4 @@ dev_prepare: compile
 	./scripts/pre_develop_hook
 
 dev:
-	erl -env ERL_MAX_ETS_TABLES 3000 -pa apps/*/ebin apps/*/test deps/*/ebin -config rel/files/sys.config -args_file rel/files/vm.args -eval "lists:map(fun application:start/1, [kernel, stdlib, asn1, crypto, public_key, ssl, compiler, syntax_tools, runtime_tools, xmerl, mnesia, lager, linc, of_config, sync])"
+	erl -env ERL_MAX_ETS_TABLES 3000 -pa apps/*/ebin apps/*/test deps/*/ebin -config rel/files/sys.config -args_file rel/files/vm.args -eval "lists:map(fun application:start/1, [kernel, stdlib, asn1, crypto, public_key, ssl, compiler, syntax_tools, runtime_tools, xmerl, mnesia, lager, linc, of_protocol, of_config, sync])"

--- a/docs/optical_extension.md
+++ b/docs/optical_extension.md
@@ -83,6 +83,7 @@ as following:
                {port,6,[{queues,[]}, {port_no, 2}]}
               ]}]}
     ]}]},
+ {of_protocol, [{no_multipart, false}]},
  {enetconf,
   [{capabilities,[{base,{1,1}},{startup,{1,0}},{'writable-running',{1,0}}]},
    {callback_module,linc_ofconfig},
@@ -125,6 +126,8 @@ the following format:
 by a controller.
 
 * Ports 1 and 6 are attached to operating system tap ports.
+
+* The `no_multipart` flag allows to disable splitting OF messages.
 
 * The config can be also generated using [LINC Configuration generator][config_generator].
 

--- a/rel/files/sys.config.orig
+++ b/rel/files/sys.config.orig
@@ -164,6 +164,13 @@
    %% , {buffer_size, 73400320}
   ]},
 
+ {of_protocol,
+  [
+   %% This flag allows to disable splitting messages into multipart
+   %% messages.
+   %% {no_multipart, true}
+  ]},
+
  {enetconf,
   [
    {capabilities, [{base, {1, 0}},


### PR DESCRIPTION
This flag allows to disable splitting OF messages.
